### PR TITLE
Add missing database field for datasette-media photo configuration

### DIFF
--- a/database/datasette.yaml
+++ b/database/datasette.yaml
@@ -14,6 +14,7 @@ plugins:
       database: "mediameta"
     photo:
       sql: "select prefixed_path as filepath from exif where FileName=:key"
+      database: "mediameta"
   datasette-enrichments-opencage:
     api_key:
       $env: OPENCAGE_API_KEY


### PR DESCRIPTION
## Summary
- Added the missing `database: mediameta` field to the photo section of datasette-media plugin configuration
- This ensures the photo section matches the structure of the thumb section

## Test plan
- [ ] Verify datasette still starts correctly with the updated configuration
- [ ] Confirm photo media queries work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)