### PR TITLE
Add configuration management for media prefix path

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ datasette = "==1.0a21"
 torch = "*"
 torchvision = "*"
 mlx-vlm = "*"
+pyyaml = "*"
 
 [dev-packages]
 

--- a/README.md
+++ b/README.md
@@ -172,13 +172,34 @@ plugins:
 ```
 The exif table contains a column called prefixed_path which contains the full path to the image. The FileName column contains the filename.
 
-I had forgotten how prefix_path was added to the exif table. I searched the code base with ripgrep `rg -n prefix_path` and found this entry in cache. I must have forgotten to write it down anywhere:
+### Managing the Media Prefix Path
+
+The media file location prefix is now managed via the `media_config.yaml` configuration file:
+
+```yaml
+# media_config.yaml
+media_prefix_path: "/Volumes/Eddie 4TB/MediaFiles/uuid"
+database_path: "database/mediameta.db"
 ```
-Library/Application Support/Code/User/History/30f82f25/DEe8.txt
-2:ALTER TABLE your_table ADD COLUMN prefixed_path TEXT;
-6:SET prefixed_path = '/Volumes/Eddie 4TB/MediaFiles/uuid' || substr(path, 2);
-11:ALTER TABLE exif ADD COLUMN prefixed_path TEXT;
-15:UPDATE exif SET prefixed_path = '/Volumes/Eddie 4TB/MediaFiles/uuid' || substr(path, 2);
+
+#### Updating the Prefix Path
+
+When the media files are moved to a new location, update the `media_prefix_path` in `media_config.yaml` and run:
+
+```bash
+python src/update_prefix_path.py
+```
+
+This script will regenerate all `prefixed_path` values in the exif table by concatenating the new prefix with the relative path stored in `SourceFile`.
+
+**Note:** Install PyYAML if not already installed: `pipenv install pyyaml`
+
+#### Original SQL Commands (for reference)
+
+The prefixed_path column was originally created with:
+```sql
+ALTER TABLE exif ADD COLUMN prefixed_path TEXT;
+UPDATE exif SET prefixed_path = '/Volumes/Eddie 4TB/MediaFiles/uuid' || substr(SourceFile, 2);
 ```
 
 

--- a/media_config.yaml
+++ b/media_config.yaml
@@ -1,0 +1,8 @@
+# Media Management Configuration
+# Configuration for managing media file paths
+
+# The base directory path where media files are stored on disk
+media_prefix_path: "/Volumes/Eddie 4TB/MediaFiles/uuid"
+
+# Path to the database file
+database_path: "database/mediameta.db"

--- a/src/update_prefix_path.py
+++ b/src/update_prefix_path.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Update the prefixed_path column in the exif table based on media_config.yaml
+
+This script reads the media prefix path from the configuration file and updates
+all rows in the exif table to regenerate the prefixed_path column.
+
+Usage:
+    python src/update_prefix_path.py
+"""
+
+import sqlite3
+import yaml
+import os
+import sys
+
+
+def load_config(config_path="media_config.yaml"):
+    """Load configuration from YAML file"""
+    if not os.path.exists(config_path):
+        print(f"Error: Configuration file '{config_path}' not found")
+        sys.exit(1)
+
+    with open(config_path, 'r') as f:
+        config = yaml.safe_load(f)
+
+    return config
+
+
+def update_prefixed_paths(db_path, media_prefix_path):
+    """Update the prefixed_path column in the exif table"""
+
+    # Connect to the database
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Count rows before update
+    cursor.execute("SELECT COUNT(*) FROM exif")
+    total_rows = cursor.fetchone()[0]
+    print(f"Found {total_rows} rows in exif table")
+
+    # Update prefixed_path by concatenating prefix with path (removing leading '.')
+    # substr(SourceFile, 2) removes the first character (the '.')
+    update_sql = """
+    UPDATE exif
+    SET prefixed_path = ? || substr(SourceFile, 2)
+    """
+
+    print(f"Updating prefixed_path with prefix: {media_prefix_path}")
+    cursor.execute(update_sql, (media_prefix_path,))
+
+    # Commit changes
+    conn.commit()
+    rows_updated = cursor.rowcount
+    print(f"Successfully updated {rows_updated} rows")
+
+    # Show sample results
+    cursor.execute("SELECT SourceFile, prefixed_path FROM exif LIMIT 3")
+    print("\nSample results:")
+    for row in cursor.fetchall():
+        print(f"  SourceFile: {row[0]}")
+        print(f"  prefixed_path: {row[1]}\n")
+
+    conn.close()
+
+
+def main():
+    # Load configuration
+    config = load_config()
+
+    media_prefix_path = config.get('media_prefix_path')
+    database_path = config.get('database_path')
+
+    if not media_prefix_path:
+        print("Error: 'media_prefix_path' not found in configuration")
+        sys.exit(1)
+
+    if not database_path:
+        print("Error: 'database_path' not found in configuration")
+        sys.exit(1)
+
+    if not os.path.exists(database_path):
+        print(f"Error: Database file '{database_path}' not found")
+        sys.exit(1)
+
+    print(f"Configuration loaded:")
+    print(f"  Media prefix path: {media_prefix_path}")
+    print(f"  Database path: {database_path}\n")
+
+    # Update the prefixed paths
+    update_prefixed_paths(database_path, media_prefix_path)
+
+    print("\n✓ Update complete!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Introduces YAML-based configuration system to manage the media file prefix path
- Makes it easier to update database when media files are moved to new locations
- Replaces hardcoded SQL UPDATE statements with a configurable approach

## Changes
- **media_config.yaml**: New configuration file storing the media prefix path and database path
- **src/update_prefix_path.py**: Python utility script to regenerate all `prefixed_path` values in the exif table based on config
- **Pipfile**: Added `pyyaml` dependency for YAML file parsing
- **README.md**: Updated documentation with instructions on using the new configuration system

## Usage
When media files are moved to a new location:
1. Edit `media_config.yaml` and update the `media_prefix_path`
2. Run: `python src/update_prefix_path.py`

The script will regenerate all full paths in the database based on the new prefix.

## Test plan
- [ ] Verify `media_config.yaml` contains correct current paths
- [ ] Install PyYAML: `pipenv install pyyaml`
- [ ] Test the update script: `python src/update_prefix_path.py`
- [ ] Verify script output shows successful update
- [ ] Check sample results match expected format
- [ ] Verify datasette-media plugin still works with updated paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)