### PR TITLE
Update database schema documentation to reflect current state

### DIFF
--- a/docs/database-schema-analysis.md
+++ b/docs/database-schema-analysis.md
@@ -3,7 +3,7 @@
 ## Database Overview
 SQLite database located at `database/mediameta.db` containing metadata for media files (photos and videos).
 
-## Tables Summary (18 tables)
+## Tables Summary (16 tables + 1 view)
 
 ### Core Media Tables
 - **thumbImages** - Stores thumbnail images with paths, binary content, file sizes, and creation dates
@@ -27,7 +27,6 @@ SQLite database located at `database/mediameta.db` containing metadata for media
 - **mappings** - Old to new filename mappings
 - **videorez** - Video resolution information (width/height)
 - **filenames** - File listings with sizes
-- **gpscage** - GPS and date metadata subset
 
 ### Duplicate Detection
 - **dups2008** - Duplicate files by CreateDate
@@ -40,7 +39,19 @@ SQLite database located at `database/mediameta.db` containing metadata for media
 - **_enrichment_jobs** - Job processing queue
 - **_enrichment_errors** - Error logs for enrichment jobs
 - **exifNoDate** / **exifAllNoDate** - EXIF data with integer date fields
-- **nonBlankRows** - Column statistics
+- **nonBlankRows** - Metadata coverage analysis (see detailed section below)
+
+### Configuration
+- **photomanage_config** - System configuration key-value store
+  - Stores: media_prefix_path (absolute path to media files)
+  - Used by: exif_with_fullpath view to compute full file paths
+  - Schema: key (PK), value, description, updated_at
+
+### Views
+- **exif_with_fullpath** - Computed view of exif table with full filesystem paths
+  - Dynamically generates `full_path` by combining `photomanage_config.media_prefix_path` with `exif.SourceFile`
+  - Example: `./0/file.jpg` → `/Volumes/Eddie 4TB/MediaFiles/uuid/0/file.jpg`
+  - Enables portable database (relative paths) with filesystem access (absolute paths)
 
 ## Database Relationships
 
@@ -58,9 +69,12 @@ Multiple tables share the `SourceFile` column as a common key:
 - exifAll
 - exifAllNoDate
 - exifNoDate
-- gpscage
 
 **Important:** All tables use consistent `./` prefix format (e.g., `./0/filename.jpg`)
+
+### Configuration Relationships
+- **exif_with_fullpath.full_path** - Computed from `photomanage_config.media_prefix_path` + `exif.SourceFile`
+- Updating `photomanage_config.media_prefix_path` automatically updates all full_path values in the view
 
 ### Other Relationships
 - **ai_description.file** - Relates to file paths for AI descriptions
@@ -100,3 +114,77 @@ Multiple tables store location data:
 - exifAll: 32,969 records
 
 The discrepancy in counts is primarily explained by the presence of 1,123 video files (which do not have thumbnails in `thumbImages`), as detailed in sourcefile-consistency-analysis.md. Following the November 2025 thumbnail upgrade, all processable images now have auto-oriented 512x512 thumbnails.
+
+## Metadata Coverage Analysis (nonBlankRows Table)
+
+The `nonBlankRows` table provides column-level statistics for the `exifAll` table, showing which EXIF metadata fields contain actual data across the media library.
+
+### Purpose
+
+This diagnostic table helps identify:
+- **Data quality** - Which metadata fields are actually populated in your media files
+- **Schema optimization** - Sparse columns that may not need indexing
+- **Coverage reporting** - Understanding metadata completeness across your library
+- **Query planning** - Knowing which of the 98 exifAll columns are worth querying
+
+### Schema
+
+```sql
+CREATE TABLE nonBlankRows (
+   Column TEXT,    -- EXIF metadata column name from exifAll
+   Count INTEGER   -- Number of non-blank, non-null values for this column
+)
+```
+
+### Data Insights
+
+The table reveals that only **17 out of 98 columns** in exifAll contain any data:
+- **SourceFile**: 616 records
+- **System timestamps**: ~221-433 records (FileAccessDate, FileModifyDate, etc.)
+- **QuickTime metadata**: ~183-395 records (ModifyDate, CreateDate, PreviewDate)
+- **GPS data**: 2-5 records (GPSLatitude, GPSLongitude, etc.)
+- **Other fields**: Various camera-specific metadata (Pentax, RIFF, etc.)
+
+This means **81 columns are completely empty** across all 32,969 records, highlighting that most EXIF fields are manufacturer-specific or format-specific.
+
+### How to Generate
+
+The nonBlankRows analysis is created using a 3-step process:
+
+**Step 1: Extract column metadata from exifAll**
+```bash
+python src/get_table_columns.py database/mediameta.db exifAll
+```
+- Uses `PRAGMA table_info('exifAll')` to retrieve all 98 columns
+- Saves column information to `columns.pickle`
+
+**Step 2: Count non-blank rows for each column**
+```bash
+python src/read_pickle.py columns.pickle database/mediameta.db exifAll
+```
+- For each column, executes: `SELECT COUNT(*) FROM exifAll WHERE TRIM(column) != '' AND column IS NOT NULL`
+- Outputs results to `database/non_blank_rows.csv`
+- Only includes columns with count > 0
+
+**Step 3: Import results to database**
+```bash
+sqlite-utils insert database/mediameta.db nonBlankRows database/non_blank_rows.csv --csv
+```
+- Loads the CSV into the nonBlankRows table
+
+### Related Files
+
+- **Scripts**:
+  - `src/get_table_columns.py` - Extracts column metadata
+  - `src/read_pickle.py` - Counts non-blank values per column
+  - `src/read_pickle_col.py` - Alternative version with column filtering
+- **Data**: `database/non_blank_rows.csv` - CSV export of analysis results
+- **Source**: `exifAll` table - Comprehensive EXIF data (98 columns, 32,969 records)
+
+### Use Cases
+
+1. **Before adding indexes** - Check if a column has enough data to justify an index
+2. **Query optimization** - Focus queries on columns that actually contain data
+3. **Schema cleanup** - Identify candidates for column removal or archival
+4. **Data migration** - Understand which metadata will transfer when migrating formats
+5. **Documentation** - Show users which EXIF fields are available in their collection


### PR DESCRIPTION
## Summary
Comprehensive update to database schema documentation to accurately reflect all 16 tables and 1 view in the mediameta.db database, including detailed documentation for the nonBlankRows metadata coverage analysis table.

## Documentation Updates

### Added Missing Tables and Views
- **photomanage_config** - Configuration key-value store
  - Stores media_prefix_path for computing full file paths
  - Schema: key (PK), value, description, updated_at
  - Example: `media_prefix_path` = `/Volumes/Eddie 4TB/MediaFiles/uuid`
  
- **exif_with_fullpath** - View (not a table)
  - Dynamically computes full filesystem paths from config + relative paths
  - Example: `./0/file.jpg` → `/Volumes/Eddie 4TB/MediaFiles/uuid/0/file.jpg`
  - Enables portable database with filesystem access

### Comprehensive nonBlankRows Documentation
Added full section documenting this diagnostic table:
- **Purpose**: Analyzes which of the 98 exifAll columns contain actual data
- **Key insight**: Only 17 columns have data, 81 are completely empty
- **Generation workflow**: 3-step process using get_table_columns.py and read_pickle.py
- **Use cases**: Data quality, schema optimization, query planning, indexing decisions
- **Related files**: Scripts, CSV exports, source tables

### Removed Obsolete References
- Removed `gpscage` table (dropped in PR #12)
- Removed from Utility Tables section
- Removed from Implicit Relationships section

### Accuracy Updates
- Fixed table count: "18 tables" → "16 tables + 1 view"
- Added Configuration Relationships section
- Documented how exif_with_fullpath depends on photomanage_config

## Impact
- Documentation now accurately reflects current database state
- Users can understand metadata coverage (17/98 columns populated)
- Clear workflow for regenerating nonBlankRows analysis
- Explains configuration-based path architecture

## Files Changed
- `docs/database-schema-analysis.md`: +92 lines, -4 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)