### PR TITLE
Add max-tokens and temperature parameters to batch processing

### DIFF
--- a/scripts/run_batch_descriptions.sh
+++ b/scripts/run_batch_descriptions.sh
@@ -6,12 +6,13 @@
 # system from sleeping. The process runs in the background and logs to a file.
 #
 # Usage:
-#   ./scripts/run_batch_descriptions.sh [directory] [batch_size] [cooldown] [model]
+#   ./scripts/run_batch_descriptions.sh [directory] [batch_size] [cooldown] [model] [max_tokens] [temp]
 #
 # Examples:
 #   ./scripts/run_batch_descriptions.sh
 #   ./scripts/run_batch_descriptions.sh database/512x512 50 60
 #   ./scripts/run_batch_descriptions.sh database/512x512 100 30 smolvlm2
+#   ./scripts/run_batch_descriptions.sh database/512x512 100 30 smolvlm 300 0.7
 #
 
 # Default values
@@ -19,6 +20,8 @@ DIRECTORY="${1:-database/512x512}"
 BATCH_SIZE="${2:-100}"
 COOLDOWN="${3:-30}"
 MODEL="${4:-smolvlm}"
+MAX_TOKENS="${5:-500}"
+TEMP="${6:-0.0}"
 
 # PID file location
 PID_FILE="batch_orchestrator.pid"
@@ -53,6 +56,8 @@ echo "Directory:      $DIRECTORY"
 echo "Batch size:     $BATCH_SIZE images per batch"
 echo "Cooldown:       ${COOLDOWN}s between batches"
 echo "Model:          $MODEL"
+echo "Max tokens:     $MAX_TOKENS"
+echo "Temperature:    $TEMP"
 echo ""
 
 # Count files
@@ -70,6 +75,8 @@ nohup caffeinate -i python3 src/batch_orchestrator.py \
     --batch-size "$BATCH_SIZE" \
     --cooldown "$COOLDOWN" \
     --model "$MODEL" \
+    --max-tokens "$MAX_TOKENS" \
+    --temp "$TEMP" \
     > logs/orchestrator_console.log 2>&1 &
 
 # Save the PID

--- a/src/batch_orchestrator.py
+++ b/src/batch_orchestrator.py
@@ -32,12 +32,15 @@ class BatchOrchestrator:
 
     def __init__(self, directory: str, batch_size: int = 100,
                  cooldown: int = 30, model: str = 'smolvlm',
-                 max_memory_percent: float = 85.0):
+                 max_memory_percent: float = 85.0,
+                 max_tokens: int = 500, temp: float = 0.0):
         self.directory = Path(directory)
         self.batch_size = batch_size
         self.cooldown = cooldown
         self.model = model
         self.max_memory_percent = max_memory_percent
+        self.max_tokens = max_tokens
+        self.temp = temp
         self.progress_file = "photo_descriptions_progress.txt"
 
         # Set up logging
@@ -155,7 +158,9 @@ class BatchOrchestrator:
             "src/generate_descriptions.py",
             str(self.directory),
             str(self.batch_size),
-            "--model", self.model
+            "--model", self.model,
+            "--max-tokens", str(self.max_tokens),
+            "--temp", str(self.temp)
         ]
 
         self.logger.info(f"Running: {' '.join(cmd)}")
@@ -193,6 +198,8 @@ class BatchOrchestrator:
         self.logger.info(f"Batch size: {self.batch_size}")
         self.logger.info(f"Cooldown: {self.cooldown}s")
         self.logger.info(f"Model: {self.model}")
+        self.logger.info(f"Max tokens: {self.max_tokens}")
+        self.logger.info(f"Temperature: {self.temp}")
         self.logger.info("=" * 70)
 
         batch_num = 0
@@ -296,6 +303,18 @@ def main():
         default=85.0,
         help='Maximum memory usage percent before pausing (default: 85.0)'
     )
+    parser.add_argument(
+        '--max-tokens',
+        type=int,
+        default=500,
+        help='Maximum tokens to generate per image (default: 500)'
+    )
+    parser.add_argument(
+        '--temp',
+        type=float,
+        default=0.0,
+        help='Temperature for generation (default: 0.0)'
+    )
 
     args = parser.parse_args()
 
@@ -310,7 +329,9 @@ def main():
         batch_size=args.batch_size,
         cooldown=args.cooldown,
         model=args.model,
-        max_memory_percent=args.max_memory
+        max_memory_percent=args.max_memory,
+        max_tokens=args.max_tokens,
+        temp=args.temp
     )
 
     orchestrator.run()


### PR DESCRIPTION
## Summary
- Add `--max-tokens` and `--temp` parameters to batch processing system
- Allow users to configure generation parameters when running batch descriptions

## Changes

**src/batch_orchestrator.py:**
- Add `max_tokens` and `temp` parameters to `__init__` method (defaults: 500, 0.0)
- Pass parameters through to `generate_descriptions.py` subprocess
- Add argparse arguments with proper help text
- Include in startup logging for visibility

**scripts/run_batch_descriptions.sh:**
- Accept `max_tokens` and `temp` as positional arguments (positions 5 and 6)
- Display values in configuration output
- Pass through to Python orchestrator

## Usage Examples

```bash
# Use defaults (500 tokens, temp 0.0)
./scripts/run_batch_descriptions.sh

# Custom tokens and temperature
./scripts/run_batch_descriptions.sh database/512x512 100 30 smolvlm 300 0.7

# Shorter descriptions with higher creativity
./scripts/run_batch_descriptions.sh database/512x512 100 30 smolvlm2 200 0.8
```

## Parameter Flow
Shell script → batch_orchestrator.py → generate_descriptions.py

## Test plan
- [x] Verify argparse help shows new parameters
- [x] Confirm parameters have correct defaults
- [ ] Test with custom values (recommend small test run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)