### PR TITLE
Handle missing media files when external drive disconnected

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,12 @@ From the `database/` directory:
 cd database
 datasette -p 8001 --root --load-extension=spatialite \
     --template-dir ../datasette/templates \
+    --plugins-dir=../datasette/plugins \
     -c ../datasette/datasette.yaml \
     mediameta.db
 ```
 
-**Note:** Templates are in `datasette/templates/`, not `database/templates/`.
+**Note:** Templates are in `datasette/templates/` and plugins are in `datasette/plugins/`.
 
 ### Plugins
 

--- a/datasette/plugins/file_exists.py
+++ b/datasette/plugins/file_exists.py
@@ -1,0 +1,7 @@
+import os
+from datasette import hookimpl
+
+
+@hookimpl
+def prepare_jinja2_environment(env):
+    env.filters["file_exists"] = lambda path: path and os.path.exists(path)

--- a/datasette/templates/pages/photo/{id}.html
+++ b/datasette/templates/pages/photo/{id}.html
@@ -66,11 +66,11 @@
             color: #e0e0e0;
         }
         .error {
-            background-color: #3d1a1a;
-            color: #ff6b6b;
+            background-color: #1a2a3d;
+            color: #6b9fff;
             padding: 20px;
             border-radius: 4px;
-            border-left: 4px solid #ff6b6b;
+            border-left: 4px solid #6b9fff;
         }
     </style>
 </head>
@@ -88,7 +88,11 @@
             </div>
 
             <div class="photo-container">
+                {% if photo.full_path|file_exists %}
                 <img src="/-/media/photo/{{ id }}" alt="{{ photo.FileName }}">
+                {% else %}
+                <p class="error">File not available - drive "{{ photo.full_path.split('/')[2] }}" is not connected.</p>
+                {% endif %}
             </div>
 
             <div class="photo-info">

--- a/datasette/templates/pages/photo/{id}.html
+++ b/datasette/templates/pages/photo/{id}.html
@@ -65,12 +65,19 @@
         .info-value {
             color: #e0e0e0;
         }
-        .error {
+        .info {
             background-color: #1a2a3d;
             color: #6b9fff;
             padding: 20px;
             border-radius: 4px;
             border-left: 4px solid #6b9fff;
+        }
+        .error {
+            background-color: #3d1a1a;
+            color: #ff6b6b;
+            padding: 20px;
+            border-radius: 4px;
+            border-left: 4px solid #ff6b6b;
         }
     </style>
 </head>
@@ -91,7 +98,8 @@
                 {% if photo.full_path|file_exists %}
                 <img src="/-/media/photo/{{ id }}" alt="{{ photo.FileName }}">
                 {% else %}
-                <p class="error">File not available - drive "{{ photo.full_path.split('/')[2] }}" is not connected.</p>
+                {% set path_parts = photo.full_path.split('/') %}
+                <p class="info">File not available - drive "{{ path_parts[2] if path_parts|length > 2 else 'external storage' }}" is not connected.</p>
                 {% endif %}
             </div>
 


### PR DESCRIPTION
## Summary
- Add `file_exists` template filter plugin to check if media files are accessible before rendering
- Shows friendly message with drive name when files are unavailable instead of 500 error
- Update README with `--plugins-dir` flag for datasette command

## Test plan
- [ ] Start datasette with external drive disconnected
- [ ] Navigate to a photo page
- [ ] Verify blue info message appears with drive name instead of 500 error
- [ ] Connect external drive and verify image loads normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)