### PR TITLE
Add semantic search to photo gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # photomanage
-Scripts and ideas to manage tons and tons of images and movies. The code was/is developted using ai coding agents. I started with chatgpt 4.0, then Claude with various models and now with Claude Code and Claude Sonnet 4.5 (as of Nov 23, 2025). 
+
+Photomanage is a repo for managing personal photos. Currently, this is for managing a static set of photos and videos. There are about 33,000 files totaling 141 Gigabytes. The database maps exif data to all the files. A table of thumbprints exists for about 31,800 files (only 15 images failed to produce thumbprints). There are about 1,100 video files.
+
+The full image files and video files live in an external drive.
 
 
 ## Find media in apple photos library
@@ -166,7 +169,7 @@ From the `database/` directory:
 
 ```bash
 cd database
-uv run datasette -p 8001 --root --load-extension=spatialite --template-dir ../datasette/templates --plugins-dir=../datasette/plugins -c ../datasette/datasette.yaml mediameta.db
+uv run datasette -p 8001 --root --load-extension=spatialite --template-dir ../datasette/templates --plugins-dir=../datasette/plugins -c ../datasette/datasette.yaml mediameta.db embeddings.db
 ```
 
 **Note:** Templates are in `datasette/templates/` and plugins are in `datasette/plugins/`.
@@ -266,6 +269,7 @@ http://127.0.0.1:8001/gallery
 ```
 
 Features:
+- Semantic search — type a natural-language query (e.g., "kids playing soccer") to find photos by meaning
 - Filter by date range (start date and/or end date)
 - Click thumbnails to view full photo with metadata
 - Pagination (100 photos per page with Previous/Next navigation)
@@ -340,16 +344,17 @@ See documentation for system architecture details:
 - [docs/sourcefile-consistency-analysis.md](docs/sourcefile-consistency-analysis.md) - Path architecture
 - [docs/database-indexes.md](docs/database-indexes.md) - Index optimization
 
-## Extensions and Embeddings
+## AI Image Descriptions
 
-Adding sqlite-vec for embeddings
+Generate natural-language descriptions of photos using SmolVLM on Apple Silicon. Descriptions are stored in the `image_description` table in `database/mediameta.db`.
 
-For Datasette:
-`datasette install datasette-sqlite-vec`
+See [docs/mlx-vlm-usage.md](docs/mlx-vlm-usage.md) for installation, usage, and batch processing details.
 
-For sqlite-utils:
-`sqlite-utils install sqlite-utils-sqlite-vec`
+## Semantic Search (Embeddings)
 
+Search your photo collection by meaning using embeddings generated from the AI descriptions. Uses Simon Willison's `llm` tool with local sentence-transformer models.
+
+See [docs/embedding-search.md](docs/embedding-search.md) for the full runbook.
 
 ## Create duptime table
 
@@ -358,15 +363,6 @@ Find thumbnails where the CreateDate is within the same second.
 `CREATE TABLE duptime AS SELECT thumbImages.content, exif.CreateDate, exif.FileName, thumbImages.size FROM exif INNER JOIN thumbImages ON exif.SourceFile = thumbImages.path WHERE exif.CreateDate IS NOT NULL AND exif.CreateDate <> '' AND exif.CreateDate IN (SELECT CreateDate FROM exif WHERE CreateDate IS NOT NULL AND exif.CreateDate <> '' GROUP BY CreateDate HAVING COUNT(*) > 1) ORDER BY exif.CreateDate;`
 
 ## Troubleshooting
-
-### Set Pipenv to Use Pyenv Python
-
-```bash
-export PIPENV_PYTHON="$HOME/.pyenv/shims/python"
-
-# Make it permanent
-echo 'export PIPENV_PYTHON="$HOME/.pyenv/shims/python"' >> ~/.zshrc
-```
 
 ### Check Python Compilation Flags
 

--- a/datasette/plugins/semantic_search.py
+++ b/datasette/plugins/semantic_search.py
@@ -1,0 +1,138 @@
+import struct
+import sqlite3
+import math
+import os
+
+from datasette import hookimpl
+from datasette.utils.asgi import Response
+
+_model = None
+_embeddings_cache = None
+
+EMBEDDINGS_DB_PATH = os.path.join(os.path.dirname(__file__), "../../database/embeddings.db")
+MEDIAMETA_DB_PATH = os.path.join(os.path.dirname(__file__), "../../database/mediameta.db")
+
+
+def _get_model():
+    global _model
+    if _model is None:
+        from sentence_transformers import SentenceTransformer
+
+        _model = SentenceTransformer("all-MiniLM-L6-v2")
+    return _model
+
+
+def _load_embeddings():
+    global _embeddings_cache
+    if _embeddings_cache is not None:
+        return _embeddings_cache
+
+    db_path = os.path.normpath(EMBEDDINGS_DB_PATH)
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT id, embedding, content FROM embeddings WHERE collection_id = 1"
+    ).fetchall()
+    conn.close()
+
+    embeddings_cache = []
+    for row_id, embedding_blob, content in rows:
+        num_floats = len(embedding_blob) // 4
+        vector = struct.unpack(f"{num_floats}f", embedding_blob)
+        norm = math.sqrt(sum(x * x for x in vector))
+        embeddings_cache.append((row_id, vector, norm, content))
+
+    _embeddings_cache = embeddings_cache
+    return _embeddings_cache
+
+
+def _cosine_similarity(vec_a, norm_a, vec_b, norm_b):
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    dot = sum(a * b for a, b in zip(vec_a, vec_b))
+    return dot / (norm_a * norm_b)
+
+
+async def search_handler(request, datasette):
+    q = request.args.get("q", "").strip()
+    if not q:
+        return Response.json({"error": "Missing 'q' parameter"}, status=400)
+
+    try:
+        n = int(request.args.get("n", "20"))
+    except ValueError:
+        n = 20
+    n = max(1, min(n, 200))
+
+    start_date = request.args.get("start_date", "").strip()
+    end_date = request.args.get("end_date", "").strip()
+
+    # If date filters are provided, build a map of SourceFile -> CreateDate
+    # so we can restrict search results to the date range
+    date_map = {}
+    date_filter_ids = None
+    if start_date or end_date:
+        meta_path = os.path.normpath(MEDIAMETA_DB_PATH)
+        conn = sqlite3.connect(meta_path)
+        sql = "SELECT SourceFile, CreateDate FROM exif WHERE CreateDate IS NOT NULL"
+        params = []
+        if start_date:
+            sql += " AND CreateDate >= ?"
+            params.append(start_date)
+        if end_date:
+            sql += " AND (CreateDate <= ? || ' 23:59:59' OR CreateDate LIKE ? || '%')"
+            params.extend([end_date, end_date])
+        rows = conn.execute(sql, params).fetchall()
+        conn.close()
+        date_map = {row[0]: row[1] for row in rows}
+        date_filter_ids = set(date_map.keys())
+
+    model = _get_model()
+    query_embedding = model.encode(q).tolist()
+    query_norm = math.sqrt(sum(x * x for x in query_embedding))
+
+    all_embeddings = _load_embeddings()
+
+    scores = []
+    for row_id, vector, norm, content in all_embeddings:
+        if date_filter_ids is not None and row_id not in date_filter_ids:
+            continue
+        score = _cosine_similarity(query_embedding, query_norm, vector, norm)
+        scores.append((score, row_id, content))
+
+    scores.sort(key=lambda x: x[0], reverse=True)
+
+    top_scores = scores[:n]
+
+    # If no date filter was applied, look up dates for the top results
+    if date_filter_ids is None:
+        source_files = [row_id for _, row_id, _ in top_scores]
+        if source_files:
+            meta_path = os.path.normpath(MEDIAMETA_DB_PATH)
+            conn = sqlite3.connect(meta_path)
+            placeholders = ",".join("?" for _ in source_files)
+            rows = conn.execute(
+                f"SELECT SourceFile, CreateDate FROM exif WHERE SourceFile IN ({placeholders})",
+                source_files,
+            ).fetchall()
+            conn.close()
+            date_map = {row[0]: row[1] for row in rows}
+
+    results = []
+    for score, row_id, content in top_scores:
+        results.append(
+            {
+                "id": row_id,
+                "score": round(score, 4),
+                "content": content or "",
+                "date": date_map.get(row_id) or "",
+            }
+        )
+
+    return Response.json(results)
+
+
+@hookimpl
+def register_routes():
+    return [
+        (r"^/search$", search_handler),
+    ]

--- a/datasette/plugins/semantic_search.py
+++ b/datasette/plugins/semantic_search.py
@@ -2,46 +2,66 @@ import struct
 import sqlite3
 import math
 import os
+import re
+import threading
 
 from datasette import hookimpl
 from datasette.utils.asgi import Response
 
 _model = None
 _embeddings_cache = None
+_lock = threading.Lock()
 
-EMBEDDINGS_DB_PATH = os.path.join(os.path.dirname(__file__), "../../database/embeddings.db")
-MEDIAMETA_DB_PATH = os.path.join(os.path.dirname(__file__), "../../database/mediameta.db")
+# Allow database paths to be configured via environment variables, with
+# sensible defaults based on the current file location.
+_default_database_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "database")
+)
+EMBEDDINGS_DB_PATH = os.getenv(
+    "EMBEDDINGS_DB_PATH",
+    os.path.join(_default_database_dir, "embeddings.db"),
+)
+MEDIAMETA_DB_PATH = os.getenv(
+    "MEDIAMETA_DB_PATH",
+    os.path.join(_default_database_dir, "mediameta.db"),
+)
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_MAX_QUERY_LENGTH = 500
 
 
 def _get_model():
     global _model
-    if _model is None:
-        from sentence_transformers import SentenceTransformer
+    with _lock:
+        if _model is None:
+            from sentence_transformers import SentenceTransformer
 
-        _model = SentenceTransformer("all-MiniLM-L6-v2")
+            _model = SentenceTransformer("all-MiniLM-L6-v2")
     return _model
 
 
 def _load_embeddings():
     global _embeddings_cache
-    if _embeddings_cache is not None:
-        return _embeddings_cache
+    with _lock:
+        if _embeddings_cache is not None:
+            return _embeddings_cache
 
-    db_path = os.path.normpath(EMBEDDINGS_DB_PATH)
-    conn = sqlite3.connect(db_path)
-    rows = conn.execute(
-        "SELECT id, embedding, content FROM embeddings WHERE collection_id = 1"
-    ).fetchall()
-    conn.close()
+        try:
+            with sqlite3.connect(EMBEDDINGS_DB_PATH) as conn:
+                rows = conn.execute(
+                    "SELECT id, embedding, content FROM embeddings WHERE collection_id = 1"
+                ).fetchall()
+        except sqlite3.Error as e:
+            raise RuntimeError(f"Failed to load embeddings: {e}")
 
-    embeddings_cache = []
-    for row_id, embedding_blob, content in rows:
-        num_floats = len(embedding_blob) // 4
-        vector = struct.unpack(f"{num_floats}f", embedding_blob)
-        norm = math.sqrt(sum(x * x for x in vector))
-        embeddings_cache.append((row_id, vector, norm, content))
+        embeddings_cache = []
+        for row_id, embedding_blob, content in rows:
+            num_floats = len(embedding_blob) // 4
+            vector = struct.unpack(f"{num_floats}f", embedding_blob)
+            norm = math.sqrt(sum(x * x for x in vector))
+            embeddings_cache.append((row_id, vector, norm, content))
 
-    _embeddings_cache = embeddings_cache
+        _embeddings_cache = embeddings_cache
     return _embeddings_cache
 
 
@@ -56,6 +76,11 @@ async def search_handler(request, datasette):
     q = request.args.get("q", "").strip()
     if not q:
         return Response.json({"error": "Missing 'q' parameter"}, status=400)
+    if len(q) > _MAX_QUERY_LENGTH:
+        return Response.json(
+            {"error": f"Query too long (max {_MAX_QUERY_LENGTH} characters)"},
+            status=400,
+        )
 
     try:
         n = int(request.args.get("n", "20"))
@@ -66,31 +91,47 @@ async def search_handler(request, datasette):
     start_date = request.args.get("start_date", "").strip()
     end_date = request.args.get("end_date", "").strip()
 
+    # Validate date format
+    if start_date and not _DATE_RE.match(start_date):
+        start_date = ""
+    if end_date and not _DATE_RE.match(end_date):
+        end_date = ""
+
     # If date filters are provided, build a map of SourceFile -> CreateDate
     # so we can restrict search results to the date range
     date_map = {}
     date_filter_ids = None
     if start_date or end_date:
-        meta_path = os.path.normpath(MEDIAMETA_DB_PATH)
-        conn = sqlite3.connect(meta_path)
-        sql = "SELECT SourceFile, CreateDate FROM exif WHERE CreateDate IS NOT NULL"
-        params = []
-        if start_date:
-            sql += " AND CreateDate >= ?"
-            params.append(start_date)
-        if end_date:
-            sql += " AND (CreateDate <= ? || ' 23:59:59' OR CreateDate LIKE ? || '%')"
-            params.extend([end_date, end_date])
-        rows = conn.execute(sql, params).fetchall()
-        conn.close()
+        try:
+            with sqlite3.connect(MEDIAMETA_DB_PATH) as conn:
+                sql = "SELECT SourceFile, CreateDate FROM exif WHERE CreateDate IS NOT NULL"
+                params = []
+                if start_date:
+                    sql += " AND CreateDate >= ?"
+                    params.append(start_date)
+                if end_date:
+                    sql += " AND (CreateDate <= ? || ' 23:59:59' OR CreateDate LIKE ? || '%')"
+                    params.extend([end_date, end_date])
+                rows = conn.execute(sql, params).fetchall()
+        except sqlite3.Error:
+            return Response.json(
+                {"error": "Unable to perform search. Please try again later."},
+                status=500,
+            )
         date_map = {row[0]: row[1] for row in rows}
         date_filter_ids = set(date_map.keys())
 
-    model = _get_model()
+    try:
+        model = _get_model()
+        all_embeddings = _load_embeddings()
+    except RuntimeError:
+        return Response.json(
+            {"error": "Unable to perform search. Please try again later."},
+            status=500,
+        )
+
     query_embedding = model.encode(q).tolist()
     query_norm = math.sqrt(sum(x * x for x in query_embedding))
-
-    all_embeddings = _load_embeddings()
 
     scores = []
     for row_id, vector, norm, content in all_embeddings:
@@ -107,15 +148,16 @@ async def search_handler(request, datasette):
     if date_filter_ids is None:
         source_files = [row_id for _, row_id, _ in top_scores]
         if source_files:
-            meta_path = os.path.normpath(MEDIAMETA_DB_PATH)
-            conn = sqlite3.connect(meta_path)
-            placeholders = ",".join("?" for _ in source_files)
-            rows = conn.execute(
-                f"SELECT SourceFile, CreateDate FROM exif WHERE SourceFile IN ({placeholders})",
-                source_files,
-            ).fetchall()
-            conn.close()
-            date_map = {row[0]: row[1] for row in rows}
+            try:
+                with sqlite3.connect(MEDIAMETA_DB_PATH) as conn:
+                    placeholders = ",".join("?" for _ in source_files)
+                    rows = conn.execute(
+                        f"SELECT SourceFile, CreateDate FROM exif WHERE SourceFile IN ({placeholders})",
+                        source_files,
+                    ).fetchall()
+                date_map = {row[0]: row[1] for row in rows}
+            except sqlite3.Error:
+                pass
 
     results = []
     for score, row_id, content in top_scores:

--- a/datasette/templates/pages/gallery.html
+++ b/datasette/templates/pages/gallery.html
@@ -40,7 +40,8 @@
             font-size: 14px;
             color: #999;
         }
-        .form-group input[type="date"] {
+        .form-group input[type="date"],
+        .form-group input[type="text"] {
             padding: 8px 12px;
             background-color: #2a2a2a;
             border: 1px solid #444;
@@ -48,9 +49,13 @@
             color: #e0e0e0;
             font-size: 14px;
         }
-        .form-group input[type="date"]:focus {
+        .form-group input[type="date"]:focus,
+        .form-group input[type="text"]:focus {
             outline: none;
             border-color: #4a9eff;
+        }
+        .form-group input[type="text"] {
+            width: 250px;
         }
         button {
             padding: 8px 20px;
@@ -64,6 +69,10 @@
         }
         button:hover {
             background-color: #3a8eef;
+        }
+        button:disabled {
+            background-color: #555;
+            cursor: not-allowed;
         }
         .reset-link {
             padding: 8px 20px;
@@ -122,6 +131,20 @@
             font-size: 12px;
             color: #999;
         }
+        .photo-score {
+            font-size: 12px;
+            color: #4a9eff;
+            margin-top: 4px;
+        }
+        .photo-description-preview {
+            font-size: 11px;
+            color: #888;
+            margin-top: 4px;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
         .no-results {
             text-align: center;
             padding: 60px 20px;
@@ -161,6 +184,110 @@
             color: #999;
             font-size: 14px;
         }
+        .search-loading {
+            text-align: center;
+            padding: 40px;
+            color: #999;
+            font-size: 16px;
+        }
+
+        /* Modal overlay */
+        .modal-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.85);
+            z-index: 1000;
+            overflow-y: auto;
+        }
+        .modal-overlay.active {
+            display: flex;
+            justify-content: center;
+            align-items: flex-start;
+            padding: 40px 20px;
+        }
+        .modal-content {
+            background-color: #252525;
+            border-radius: 12px;
+            max-width: 800px;
+            width: 100%;
+            overflow: hidden;
+        }
+        .modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 16px 20px;
+            border-bottom: 1px solid #333;
+        }
+        .modal-header h3 {
+            margin: 0;
+            font-size: 16px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .modal-close {
+            background: none;
+            border: none;
+            color: #999;
+            font-size: 24px;
+            cursor: pointer;
+            padding: 0 4px;
+        }
+        .modal-close:hover {
+            color: #fff;
+        }
+        .modal-body {
+            display: flex;
+            gap: 20px;
+            padding: 20px;
+        }
+        .modal-image {
+            flex-shrink: 0;
+            width: 300px;
+            height: 300px;
+            object-fit: cover;
+            border-radius: 8px;
+            background-color: #1a1a1a;
+        }
+        .modal-details {
+            flex: 1;
+            min-width: 0;
+        }
+        .modal-score {
+            font-size: 14px;
+            color: #4a9eff;
+            margin-bottom: 12px;
+        }
+        .modal-description {
+            font-size: 14px;
+            line-height: 1.6;
+            color: #ccc;
+            white-space: pre-wrap;
+        }
+        .modal-link {
+            display: inline-block;
+            margin-top: 16px;
+            color: #4a9eff;
+            text-decoration: none;
+            font-size: 14px;
+        }
+        .modal-link:hover {
+            text-decoration: underline;
+        }
+        @media (max-width: 700px) {
+            .modal-body {
+                flex-direction: column;
+            }
+            .modal-image {
+                width: 100%;
+                height: 250px;
+            }
+        }
     </style>
 </head>
 <body>
@@ -168,7 +295,11 @@
         <div class="header">
             <h1>Photo Gallery</h1>
 
-            <form class="filter-form" method="get">
+            <form class="filter-form" method="get" id="filterForm">
+                <div class="form-group">
+                    <label for="search_query">Semantic Search</label>
+                    <input type="text" id="search_query" name="q" placeholder="e.g. kids playing soccer" value="{{ request.args.get('q', '') }}">
+                </div>
                 <div class="form-group">
                     <label for="start_date">Start Date</label>
                     <input type="date" id="start_date" name="start_date" value="{{ request.args.get('start_date', '') }}">
@@ -177,11 +308,19 @@
                     <label for="end_date">End Date</label>
                     <input type="date" id="end_date" name="end_date" value="{{ request.args.get('end_date', '') }}">
                 </div>
-                <button type="submit">Filter</button>
+                <button type="submit" id="filterBtn">Filter</button>
+                <button type="button" id="searchBtn" style="display:none;">Search</button>
                 <a href="/gallery" class="reset-link">Reset</a>
             </form>
         </div>
 
+        <div id="searchResults" style="display: none;">
+            <div class="search-loading" id="searchLoading">Loading search results...</div>
+            <div class="gallery-info" id="searchInfo"></div>
+            <div class="gallery-grid" id="searchGrid"></div>
+        </div>
+
+        <div id="galleryContent">
         {# Query photos based on date filter with pagination #}
         {% set start_date = request.args.get('start_date', '') %}
         {% set end_date = request.args.get('end_date', '') %}
@@ -269,6 +408,174 @@
                 <p>Try adjusting your date range or <a href="/gallery" style="color: #4a9eff;">reset the filter</a></p>
             </div>
         {% endif %}
+        </div>
     </div>
+
+    <!-- Modal for search result detail -->
+    <div class="modal-overlay" id="resultModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 id="modalTitle"></h3>
+                <button class="modal-close" id="modalClose">&times;</button>
+            </div>
+            <div class="modal-body">
+                <img class="modal-image" id="modalImage" src="" alt="">
+                <div class="modal-details">
+                    <div class="modal-score" id="modalScore"></div>
+                    <div class="photo-date" id="modalDate" style="margin-bottom: 12px;"></div>
+                    <div class="modal-description" id="modalDescription"></div>
+                    <a class="modal-link" id="modalLink" href="#" target="_blank">View photo page →</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    (function() {
+        const searchInput = document.getElementById('search_query');
+        const filterForm = document.getElementById('filterForm');
+        const searchResults = document.getElementById('searchResults');
+        const searchLoading = document.getElementById('searchLoading');
+        const searchInfo = document.getElementById('searchInfo');
+        const searchGrid = document.getElementById('searchGrid');
+        const galleryContent = document.getElementById('galleryContent');
+        const modal = document.getElementById('resultModal');
+        const modalClose = document.getElementById('modalClose');
+
+        function extractFilename(filePath) {
+            // filePath is like "./0/abc123.JPG" — extract just the filename
+            return filePath.split('/').pop();
+        }
+
+        function thumbUrl(filePath) {
+            // filePath is like "./0/abc123.JPG" — strip leading "./"
+            return '/-/media/thumb/' + filePath.replace(/^\.\//, '');
+        }
+
+        function showModal(result) {
+            const filename = extractFilename(result.id);
+            document.getElementById('modalTitle').textContent = filename;
+            document.getElementById('modalImage').src = thumbUrl(result.id);
+            document.getElementById('modalScore').textContent = 'Similarity: ' + (result.score * 100).toFixed(1) + '%';
+            var dateEl = document.getElementById('modalDate');
+            if (result.date) {
+                dateEl.textContent = result.date.substring(0, 10);
+                dateEl.style.display = '';
+            } else {
+                dateEl.style.display = 'none';
+            }
+            document.getElementById('modalDescription').textContent = result.content || 'No description available.';
+            document.getElementById('modalLink').href = '/photo/' + encodeURIComponent(filename);
+            modal.classList.add('active');
+        }
+
+        modalClose.addEventListener('click', function() {
+            modal.classList.remove('active');
+        });
+
+        modal.addEventListener('click', function(e) {
+            if (e.target === modal) {
+                modal.classList.remove('active');
+            }
+        });
+
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape') {
+                modal.classList.remove('active');
+            }
+        });
+
+        function performSearch(query) {
+            if (!query.trim()) {
+                searchResults.style.display = 'none';
+                galleryContent.style.display = '';
+                return;
+            }
+
+            galleryContent.style.display = 'none';
+            searchResults.style.display = '';
+            searchLoading.style.display = '';
+            searchGrid.innerHTML = '';
+            searchInfo.textContent = '';
+
+            var searchUrl = '/search?q=' + encodeURIComponent(query) + '&n=50';
+            var startVal = document.getElementById('start_date').value;
+            var endVal = document.getElementById('end_date').value;
+            if (startVal) searchUrl += '&start_date=' + encodeURIComponent(startVal);
+            if (endVal) searchUrl += '&end_date=' + encodeURIComponent(endVal);
+
+            fetch(searchUrl)
+                .then(function(r) { return r.json(); })
+                .then(function(results) {
+                    searchLoading.style.display = 'none';
+
+                    if (results.error) {
+                        searchInfo.textContent = 'Error: ' + results.error;
+                        return;
+                    }
+
+                    searchInfo.textContent = 'Found ' + results.length + ' result(s) for "' + query + '"';
+
+                    results.forEach(function(result) {
+                        var card = document.createElement('div');
+                        card.className = 'photo-card';
+                        card.style.cursor = 'pointer';
+
+                        var filename = extractFilename(result.id);
+                        var preview = (result.content || '').substring(0, 120);
+                        if ((result.content || '').length > 120) preview += '...';
+
+                        var dateHtml = result.date ? '<div class="photo-date">' + result.date.substring(0, 10) + '</div>' : '';
+
+                        card.innerHTML =
+                            '<img src="' + thumbUrl(result.id) + '"' +
+                            ' alt="' + filename + '"' +
+                            ' class="photo-thumbnail" loading="lazy">' +
+                            '<div class="photo-info">' +
+                            '<div class="photo-filename">' + filename + '</div>' +
+                            dateHtml +
+                            '<div class="photo-score">Score: ' + (result.score * 100).toFixed(1) + '%</div>' +
+                            '<div class="photo-description-preview">' + preview + '</div>' +
+                            '</div>';
+
+                        card.addEventListener('click', function() {
+                            showModal(result);
+                        });
+
+                        searchGrid.appendChild(card);
+                    });
+                })
+                .catch(function(err) {
+                    searchLoading.style.display = 'none';
+                    searchInfo.textContent = 'Search failed: ' + err.message;
+                });
+        }
+
+        filterForm.addEventListener('submit', function(e) {
+            var query = searchInput.value.trim();
+            if (query) {
+                e.preventDefault();
+                performSearch(query);
+                // Update URL without reload
+                var url = new URL(window.location);
+                url.searchParams.set('q', query);
+                var sd = document.getElementById('start_date').value;
+                var ed = document.getElementById('end_date').value;
+                if (sd) url.searchParams.set('start_date', sd); else url.searchParams.delete('start_date');
+                if (ed) url.searchParams.set('end_date', ed); else url.searchParams.delete('end_date');
+                url.searchParams.delete('page');
+                history.pushState({}, '', url);
+            }
+            // If no search query, let the form submit normally for date filtering
+        });
+
+        // On page load, check if there's a search query in the URL
+        var initialQuery = new URLSearchParams(window.location.search).get('q');
+        if (initialQuery) {
+            searchInput.value = initialQuery;
+            performSearch(initialQuery);
+        }
+    })();
+    </script>
 </body>
 </html>

--- a/datasette/templates/pages/gallery.html
+++ b/datasette/templates/pages/gallery.html
@@ -309,7 +309,6 @@
                     <input type="date" id="end_date" name="end_date" value="{{ request.args.get('end_date', '') }}">
                 </div>
                 <button type="submit" id="filterBtn">Filter</button>
-                <button type="button" id="searchBtn" style="display:none;">Search</button>
                 <a href="/gallery" class="reset-link">Reset</a>
             </form>
         </div>
@@ -416,7 +415,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h3 id="modalTitle"></h3>
-                <button class="modal-close" id="modalClose">&times;</button>
+                <button class="modal-close" id="modalClose" aria-label="Close modal">&times;</button>
             </div>
             <div class="modal-body">
                 <img class="modal-image" id="modalImage" src="" alt="">
@@ -456,6 +455,7 @@
             const filename = extractFilename(result.id);
             document.getElementById('modalTitle').textContent = filename;
             document.getElementById('modalImage').src = thumbUrl(result.id);
+            document.getElementById('modalImage').alt = filename;
             document.getElementById('modalScore').textContent = 'Similarity: ' + (result.score * 100).toFixed(1) + '%';
             var dateEl = document.getElementById('modalDate');
             if (result.date) {
@@ -525,18 +525,39 @@
                         var preview = (result.content || '').substring(0, 120);
                         if ((result.content || '').length > 120) preview += '...';
 
-                        var dateHtml = result.date ? '<div class="photo-date">' + result.date.substring(0, 10) + '</div>' : '';
+                        var img = document.createElement('img');
+                        img.src = thumbUrl(result.id);
+                        img.alt = filename;
+                        img.className = 'photo-thumbnail';
+                        img.loading = 'lazy';
+                        card.appendChild(img);
 
-                        card.innerHTML =
-                            '<img src="' + thumbUrl(result.id) + '"' +
-                            ' alt="' + filename + '"' +
-                            ' class="photo-thumbnail" loading="lazy">' +
-                            '<div class="photo-info">' +
-                            '<div class="photo-filename">' + filename + '</div>' +
-                            dateHtml +
-                            '<div class="photo-score">Score: ' + (result.score * 100).toFixed(1) + '%</div>' +
-                            '<div class="photo-description-preview">' + preview + '</div>' +
-                            '</div>';
+                        var info = document.createElement('div');
+                        info.className = 'photo-info';
+
+                        var filenameDiv = document.createElement('div');
+                        filenameDiv.className = 'photo-filename';
+                        filenameDiv.textContent = filename;
+                        info.appendChild(filenameDiv);
+
+                        if (result.date) {
+                            var dateDiv = document.createElement('div');
+                            dateDiv.className = 'photo-date';
+                            dateDiv.textContent = result.date.substring(0, 10);
+                            info.appendChild(dateDiv);
+                        }
+
+                        var scoreDiv = document.createElement('div');
+                        scoreDiv.className = 'photo-score';
+                        scoreDiv.textContent = 'Score: ' + (result.score * 100).toFixed(1) + '%';
+                        info.appendChild(scoreDiv);
+
+                        var previewDiv = document.createElement('div');
+                        previewDiv.className = 'photo-description-preview';
+                        previewDiv.textContent = preview;
+                        info.appendChild(previewDiv);
+
+                        card.appendChild(info);
 
                         card.addEventListener('click', function() {
                             showModal(result);
@@ -547,7 +568,7 @@
                 })
                 .catch(function(err) {
                     searchLoading.style.display = 'none';
-                    searchInfo.textContent = 'Search failed: ' + err.message;
+                    searchInfo.textContent = 'Unable to perform search. Please try again later.';
                 });
         }
 

--- a/docs/embedding-search.md
+++ b/docs/embedding-search.md
@@ -226,10 +226,22 @@ uv run datasette -p 8001 --root \
 
 This makes the embeddings table browsable at `http://127.0.0.1:8001/embeddings/embeddings`.
 
-For embedding-powered search in the Datasette web UI, install [datasette-llm-embed](https://github.com/simonw/datasette-llm-embed):
+### Gallery Semantic Search
+
+The gallery page at `/gallery` includes a semantic search box. Type a natural-language query (e.g., "kids playing soccer", "beach sunset") and click Filter. The search:
+
+1. Calls the `/search?q=<query>&n=50` JSON endpoint (provided by `datasette/plugins/semantic_search.py`)
+2. Loads the `all-MiniLM-L6-v2` sentence-transformers model on first request (~90MB memory)
+3. Reads all embeddings from `database/embeddings.db` into memory
+4. Encodes the query text and computes cosine similarity against all stored vectors
+5. Returns the top N results ranked by similarity score
+
+Results appear as thumbnail cards with similarity scores and description previews. Click a card to see the full AI description and a link to the photo detail page. Clear the search box and click Filter to return to the normal date-filtered gallery.
+
+The `/search` endpoint also works as a standalone JSON API:
 
 ```bash
-datasette install datasette-llm-embed
+curl 'http://127.0.0.1:8001/search?q=beach+sunset&n=5'
 ```
 
 Because `embeddings.db` and `mediameta.db` are served together, you can write cross-database SQL in Datasette's query editor to join search results back to the source descriptions or EXIF data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "rawpy",
     "requests",
     "safetensors",
+    "sentence-transformers",
     "sqlite-utils",
     "torch",
     "torchvision",

--- a/uv.lock
+++ b/uv.lock
@@ -781,6 +781,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071 },
+]
+
+[[package]]
 name = "logfury"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1286,6 +1295,7 @@ dependencies = [
     { name = "rawpy" },
     { name = "requests" },
     { name = "safetensors" },
+    { name = "sentence-transformers" },
     { name = "sqlite-utils" },
     { name = "torch" },
     { name = "torchvision" },
@@ -1318,6 +1328,7 @@ requires-dist = [
     { name = "rawpy" },
     { name = "requests" },
     { name = "safetensors" },
+    { name = "sentence-transformers" },
     { name = "sqlite-utils" },
     { name = "torch" },
     { name = "torchvision" },
@@ -1697,6 +1708,26 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242 },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075 },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492 },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904 },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359 },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898 },
+]
+
+[[package]]
 name = "scipy"
 version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1724,6 +1755,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552 },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bc/0bc9c0ec1cf83ab2ec6e6f38667d167349b950fff6dd2086b79bd360eeca/sentence_transformers-5.2.2.tar.gz", hash = "sha256:7033ee0a24bc04c664fd490abf2ef194d387b3a58a97adcc528783ff505159fa", size = 381607 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/21/7e925890636791386e81b52878134f114d63072e79fffe14cdcc5e7a5e6a/sentence_transformers-5.2.2-py3-none-any.whl", hash = "sha256:280ac54bffb84c110726b4d8848ba7b7c60813b9034547f8aea6e9a345cd1c23", size = 494106 },
 ]
 
 [[package]]
@@ -1856,6 +1906,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252 },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a `/search` JSON endpoint via a new Datasette plugin (`semantic_search.py`) that loads the `all-MiniLM-L6-v2` sentence-transformers model and computes cosine similarity against 31,836 pre-computed embeddings
- Adds a semantic search input to the gallery page — results show as thumbnail cards with similarity score, date, and description preview; clicking opens a modal with the full AI description
- Search results respect date range filters (start/end date)
- Adds `sentence-transformers` as a project dependency

## Test plan
- [ ] Start Datasette with `embeddings.db`: `cd database && uv run datasette -p 8001 --root --load-extension=spatialite --template-dir ../datasette/templates --plugins-dir=../datasette/plugins -c ../datasette/datasette.yaml mediameta.db embeddings.db`
- [ ] Visit `/gallery`, type a query (e.g. "kids playing soccer"), click Filter — verify ranked thumbnail results appear
- [ ] Click a result card — verify modal shows full description, score, date, and "View photo page" link opens in new tab
- [ ] Set date range + search query — verify results are filtered to that date range
- [ ] Clear search, click Filter — verify normal date-filtered gallery returns
- [ ] Test `/search?q=beach&n=5` returns JSON directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)