### PR TITLE
Full-size photo display, back navigation, and improved pagination

### DIFF
--- a/datasette/plugins/raw_photo.py
+++ b/datasette/plugins/raw_photo.py
@@ -1,0 +1,77 @@
+import asyncio
+import io
+import sqlite3
+import os
+
+from datasette import hookimpl
+from datasette.utils.asgi import Response
+
+_default_database_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "database")
+)
+MEDIAMETA_DB_PATH = os.getenv(
+    "MEDIAMETA_DB_PATH",
+    os.path.join(_default_database_dir, "mediameta.db"),
+)
+
+RAW_EXTENSIONS = {"nef", "cr2", "cr3", "arw", "dng", "raf", "orf", "rw2", "pef", "srw"}
+
+
+def _convert_raw_to_jpeg(filepath: str) -> bytes:
+    import rawpy
+    from PIL import Image
+
+    with rawpy.imread(filepath) as raw:
+        rgb = raw.postprocess()
+    img = Image.fromarray(rgb)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=90)
+    return buf.getvalue()
+
+
+async def raw_photo_handler(request, datasette):
+    filename = request.url_vars.get("filename", "")
+    if not filename:
+        return Response("Missing filename", status=400, content_type="text/plain")
+
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext not in RAW_EXTENSIONS:
+        return Response("Not a RAW file", status=400, content_type="text/plain")
+
+    try:
+        with sqlite3.connect(MEDIAMETA_DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT full_path FROM exif_with_fullpath WHERE FileName = ?",
+                (filename,),
+            ).fetchone()
+    except sqlite3.Error as e:
+        return Response(f"Database error: {e}", status=500, content_type="text/plain")
+
+    if not row:
+        return Response("Photo not found", status=404, content_type="text/plain")
+
+    full_path = row[0]
+    if not os.path.exists(full_path):
+        return Response("File not on disk", status=404, content_type="text/plain")
+
+    try:
+        loop = asyncio.get_event_loop()
+        jpeg_bytes = await loop.run_in_executor(None, _convert_raw_to_jpeg, full_path)
+    except Exception as e:
+        return Response(
+            f"Conversion failed: {e}", status=500, content_type="text/plain"
+        )
+
+    return Response(
+        jpeg_bytes,
+        status=200,
+        headers={"Cache-Control": "max-age=3600"},
+        content_type="image/jpeg",
+    )
+
+
+@hookimpl
+def register_routes():
+    return [
+        (r"^/raw-photo/(?P<filename>.+)$", raw_photo_handler),
+    ]

--- a/datasette/plugins/raw_photo.py
+++ b/datasette/plugins/raw_photo.py
@@ -1,10 +1,13 @@
 import asyncio
 import io
+import logging
 import sqlite3
 import os
 
 from datasette import hookimpl
 from datasette.utils.asgi import Response
+
+logger = logging.getLogger(__name__)
 
 _default_database_dir = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "database")
@@ -45,7 +48,8 @@ async def raw_photo_handler(request, datasette):
                 (filename,),
             ).fetchone()
     except sqlite3.Error as e:
-        return Response(f"Database error: {e}", status=500, content_type="text/plain")
+        logger.error("Database error looking up %s: %s", filename, e)
+        return Response("Internal server error", status=500, content_type="text/plain")
 
     if not row:
         return Response("Photo not found", status=404, content_type="text/plain")
@@ -55,12 +59,11 @@ async def raw_photo_handler(request, datasette):
         return Response("File not on disk", status=404, content_type="text/plain")
 
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         jpeg_bytes = await loop.run_in_executor(None, _convert_raw_to_jpeg, full_path)
     except Exception as e:
-        return Response(
-            f"Conversion failed: {e}", status=500, content_type="text/plain"
-        )
+        logger.error("RAW conversion failed for %s: %s", full_path, e)
+        return Response("Conversion failed", status=500, content_type="text/plain")
 
     return Response(
         jpeg_bytes,

--- a/datasette/templates/pages/gallery.html
+++ b/datasette/templates/pages/gallery.html
@@ -180,9 +180,18 @@
             cursor: not-allowed;
             pointer-events: none;
         }
-        .pagination .page-info {
-            color: #999;
+        .pagination .page-current {
+            padding: 10px 14px;
+            background-color: #1a5cbb;
+            color: white;
+            border-radius: 4px;
             font-size: 14px;
+            font-weight: bold;
+        }
+        .pagination .page-ellipsis {
+            color: #666;
+            font-size: 14px;
+            padding: 0 4px;
         }
         .search-loading {
             text-align: center;
@@ -328,11 +337,10 @@
         {% set offset = (page - 1) * per_page %}
 
         {% if start_date and end_date %}
-            {# Use parameterized query to prevent SQL injection #}
-            {# Use LIKE for end date to include all times on that day #}
-            {% set photos = sql("SELECT e.FileName, e.CreateDate, e.SourceFile FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate >= :start AND (e.CreateDate <= :end || ' 23:59:59' OR e.CreateDate LIKE :end || '%') ORDER BY e.CreateDate DESC LIMIT :limit OFFSET :offset", {"start": start_date, "end": end_date, "limit": per_page + 1, "offset": offset}, database="mediameta") %}
+            {# When start_date is set, sort ASC so user sees photos from the start of their range #}
+            {% set photos = sql("SELECT e.FileName, e.CreateDate, e.SourceFile FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate >= :start AND (e.CreateDate <= :end || ' 23:59:59' OR e.CreateDate LIKE :end || '%') ORDER BY e.CreateDate ASC LIMIT :limit OFFSET :offset", {"start": start_date, "end": end_date, "limit": per_page + 1, "offset": offset}, database="mediameta") %}
         {% elif start_date %}
-            {% set photos = sql("SELECT e.FileName, e.CreateDate, e.SourceFile FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate >= :start ORDER BY e.CreateDate DESC LIMIT :limit OFFSET :offset", {"start": start_date, "limit": per_page + 1, "offset": offset}, database="mediameta") %}
+            {% set photos = sql("SELECT e.FileName, e.CreateDate, e.SourceFile FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate >= :start ORDER BY e.CreateDate ASC LIMIT :limit OFFSET :offset", {"start": start_date, "limit": per_page + 1, "offset": offset}, database="mediameta") %}
         {% elif end_date %}
             {# Use LIKE to include all times on the end date #}
             {% set photos = sql("SELECT e.FileName, e.CreateDate, e.SourceFile FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate <= :end || ' 23:59:59' OR e.CreateDate LIKE :end || '%' ORDER BY e.CreateDate DESC LIMIT :limit OFFSET :offset", {"end": end_date, "limit": per_page + 1, "offset": offset}, database="mediameta") %}
@@ -341,13 +349,31 @@
             {% set photos = sql("SELECT e.FileName, e.CreateDate, e.SourceFile FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate IS NOT NULL ORDER BY e.CreateDate DESC LIMIT :limit OFFSET :offset", {"limit": per_page + 1, "offset": offset}, database="mediameta") %}
         {% endif %}
 
+        {# Get total count for pagination #}
+        {% if start_date and end_date %}
+            {% set count_row = sql("SELECT COUNT(*) as n FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate >= :start AND (e.CreateDate <= :end || ' 23:59:59' OR e.CreateDate LIKE :end || '%')", {"start": start_date, "end": end_date}, database="mediameta") %}
+        {% elif start_date %}
+            {% set count_row = sql("SELECT COUNT(*) as n FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate >= :start", {"start": start_date}, database="mediameta") %}
+        {% elif end_date %}
+            {% set count_row = sql("SELECT COUNT(*) as n FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate <= :end || ' 23:59:59' OR e.CreateDate LIKE :end || '%'", {"end": end_date}, database="mediameta") %}
+        {% else %}
+            {% set count_row = sql("SELECT COUNT(*) as n FROM exif e INNER JOIN thumbImages t ON e.SourceFile = t.path WHERE e.CreateDate IS NOT NULL", {}, database="mediameta") %}
+        {% endif %}
+        {% set total_count = count_row[0].n %}
+        {% set total_pages = ((total_count - 1) // per_page) + 1 %}
+
         {# Check if there are more results #}
         {% set has_more = photos|length > per_page %}
         {% set display_photos = photos[:per_page] %}
 
+        {# Build base URL for pagination links #}
+        {% set base_url = '/gallery?' %}
+        {% if start_date %}{% set base_url = base_url ~ 'start_date=' ~ start_date ~ '&' %}{% endif %}
+        {% if end_date %}{% set base_url = base_url ~ 'end_date=' ~ end_date ~ '&' %}{% endif %}
+
         {% if display_photos %}
             <div class="gallery-info">
-                Showing {{ display_photos|length }} photo(s)
+                Showing {{ offset + 1 }}–{{ offset + display_photos|length }} of {{ total_count }} photo(s)
                 {% if start_date and end_date %}
                     from {{ start_date }} to {{ end_date }}
                 {% elif start_date %}
@@ -357,13 +383,12 @@
                 {% else %}
                     (most recent)
                 {% endif %}
-                - Page {{ page }}
             </div>
 
             <div class="gallery-grid">
                 {% for photo in display_photos %}
                 <div class="photo-card">
-                    <a href="/photo/{{ photo.FileName }}">
+                    <a href="/photo/{{ photo.FileName }}?{% if start_date %}start_date={{ start_date }}&{% endif %}{% if end_date %}end_date={{ end_date }}&{% endif %}{% if page > 1 %}page={{ page }}{% endif %}">
                         <img src="/-/media/thumb/{{ photo.SourceFile|replace('./', '') }}"
                              alt="{{ photo.FileName }}"
                              class="photo-thumbnail"
@@ -388,15 +413,34 @@
             {# Pagination controls #}
             <div class="pagination">
                 {% if page > 1 %}
-                    <a href="/gallery?{% if start_date %}start_date={{ start_date }}&{% endif %}{% if end_date %}end_date={{ end_date }}&{% endif %}page={{ page - 1 }}">← Previous</a>
+                    <a href="{{ base_url }}page={{ page - 1 }}">← Prev</a>
                 {% else %}
-                    <a href="#" class="disabled">← Previous</a>
+                    <a href="#" class="disabled">← Prev</a>
                 {% endif %}
 
-                <span class="page-info">Page {{ page }}</span>
+                {# Build visible page numbers: first, last, and window around current #}
+                {% set visible = [] %}
+                {% for p in range(1, total_pages + 1) %}
+                    {% if p == 1 or p == total_pages or (p >= page - 2 and p <= page + 2) %}
+                        {% if visible.append(p) %}{% endif %}
+                    {% endif %}
+                {% endfor %}
+
+                {% set prev_p = namespace(val=0) %}
+                {% for p in visible %}
+                    {% if prev_p.val and p - prev_p.val > 1 %}
+                        <span class="page-ellipsis">…</span>
+                    {% endif %}
+                    {% if p == page %}
+                        <span class="page-current">{{ p }}</span>
+                    {% else %}
+                        <a href="{{ base_url }}page={{ p }}">{{ p }}</a>
+                    {% endif %}
+                    {% set prev_p.val = p %}
+                {% endfor %}
 
                 {% if has_more %}
-                    <a href="/gallery?{% if start_date %}start_date={{ start_date }}&{% endif %}{% if end_date %}end_date={{ end_date }}&{% endif %}page={{ page + 1 }}">Next →</a>
+                    <a href="{{ base_url }}page={{ page + 1 }}">Next →</a>
                 {% else %}
                     <a href="#" class="disabled">Next →</a>
                 {% endif %}
@@ -465,7 +509,15 @@
                 dateEl.style.display = 'none';
             }
             document.getElementById('modalDescription').textContent = result.content || 'No description available.';
-            document.getElementById('modalLink').href = '/photo/' + encodeURIComponent(filename);
+            var backParams = [];
+            if (query) backParams.push('q=' + encodeURIComponent(query));
+            var sd = document.getElementById('start_date').value;
+            var ed = document.getElementById('end_date').value;
+            if (sd) backParams.push('start_date=' + encodeURIComponent(sd));
+            if (ed) backParams.push('end_date=' + encodeURIComponent(ed));
+            var photoUrl = '/photo/' + encodeURIComponent(filename);
+            if (backParams.length) photoUrl += '?' + backParams.join('&');
+            document.getElementById('modalLink').href = photoUrl;
             modal.classList.add('active');
         }
 

--- a/datasette/templates/pages/gallery.html
+++ b/datasette/templates/pages/gallery.html
@@ -388,7 +388,7 @@
             <div class="gallery-grid">
                 {% for photo in display_photos %}
                 <div class="photo-card">
-                    <a href="/photo/{{ photo.FileName }}?{% if start_date %}start_date={{ start_date }}&{% endif %}{% if end_date %}end_date={{ end_date }}&{% endif %}{% if page > 1 %}page={{ page }}{% endif %}">
+                    <a href="/photo/{{ photo.FileName|urlencode }}?{% if start_date %}start_date={{ start_date|urlencode }}&{% endif %}{% if end_date %}end_date={{ end_date|urlencode }}&{% endif %}{% if page > 1 %}page={{ page }}{% endif %}">
                         <img src="/-/media/thumb/{{ photo.SourceFile|replace('./', '') }}"
                              alt="{{ photo.FileName }}"
                              class="photo-thumbnail"
@@ -418,26 +418,30 @@
                     <a href="#" class="disabled">← Prev</a>
                 {% endif %}
 
-                {# Build visible page numbers: first, last, and window around current #}
-                {% set visible = [] %}
-                {% for p in range(1, total_pages + 1) %}
-                    {% if p == 1 or p == total_pages or (p >= page - 2 and p <= page + 2) %}
-                        {% if visible.append(p) %}{% endif %}
-                    {% endif %}
-                {% endfor %}
+                {# Compute window bounds directly — O(1), no full-range iteration #}
+                {% set w_start = page - 2 if page - 2 > 1 else 1 %}
+                {% set w_end = page + 2 if page + 2 < total_pages else total_pages %}
 
-                {% set prev_p = namespace(val=0) %}
-                {% for p in visible %}
-                    {% if prev_p.val and p - prev_p.val > 1 %}
-                        <span class="page-ellipsis">…</span>
-                    {% endif %}
+                {# Page 1 if outside window #}
+                {% if w_start > 1 %}
+                    <a href="{{ base_url }}page=1">1</a>
+                {% endif %}
+                {% if w_start > 2 %}<span class="page-ellipsis">…</span>{% endif %}
+
+                {# Window around current page #}
+                {% for p in range(w_start, w_end + 1) %}
                     {% if p == page %}
                         <span class="page-current">{{ p }}</span>
                     {% else %}
                         <a href="{{ base_url }}page={{ p }}">{{ p }}</a>
                     {% endif %}
-                    {% set prev_p.val = p %}
                 {% endfor %}
+
+                {# Last page if outside window #}
+                {% if w_end < total_pages - 1 %}<span class="page-ellipsis">…</span>{% endif %}
+                {% if w_end < total_pages %}
+                    <a href="{{ base_url }}page={{ total_pages }}">{{ total_pages }}</a>
+                {% endif %}
 
                 {% if has_more %}
                     <a href="{{ base_url }}page={{ page + 1 }}">Next →</a>
@@ -510,7 +514,8 @@
             }
             document.getElementById('modalDescription').textContent = result.content || 'No description available.';
             var backParams = [];
-            if (query) backParams.push('q=' + encodeURIComponent(query));
+            var currentQuery = searchInput.value.trim();
+            if (currentQuery) backParams.push('q=' + encodeURIComponent(currentQuery));
             var sd = document.getElementById('start_date').value;
             var ed = document.getElementById('end_date').value;
             if (sd) backParams.push('start_date=' + encodeURIComponent(sd));

--- a/datasette/templates/pages/photo/{id}.html
+++ b/datasette/templates/pages/photo/{id}.html
@@ -91,15 +91,34 @@
 
             <div class="photo-header">
                 <h1>{{ photo.FileName }}</h1>
+                {% set back_q = request.args.get('q', '') %}
+                {% set back_start = request.args.get('start_date', '') %}
+                {% set back_end = request.args.get('end_date', '') %}
+                {% set back_page = request.args.get('page', '') %}
+                {% set back_url = '/gallery?' %}
+                {% if back_q %}{% set back_url = back_url ~ 'q=' ~ back_q ~ '&' %}{% endif %}
+                {% if back_start %}{% set back_url = back_url ~ 'start_date=' ~ back_start ~ '&' %}{% endif %}
+                {% if back_end %}{% set back_url = back_url ~ 'end_date=' ~ back_end ~ '&' %}{% endif %}
+                {% if back_page %}{% set back_url = back_url ~ 'page=' ~ back_page %}{% endif %}
+                <a href="{{ back_url }}">← Back to gallery</a>
+                &nbsp;&nbsp;
                 <a href="/mediameta/exif_with_fullpath?FileName={{ id }}">View in database</a>
             </div>
 
             <div class="photo-container">
+                {% set ext = id.split('.')|last|lower %}
+                {% set raw_formats = ['nef', 'cr2', 'cr3', 'arw', 'dng', 'raf', 'orf', 'rw2', 'pef', 'srw'] %}
+                {% set is_raw = ext in raw_formats %}
                 {% if photo.full_path|file_exists %}
-                <img src="/-/media/photo/{{ id }}" alt="{{ photo.FileName }}">
+                    {% if is_raw %}
+                        <img src="/raw-photo/{{ id }}" alt="{{ photo.FileName }}">
+                        <p class="info" style="margin-top: 12px;">RAW file ({{ ext|upper }}) — converted to JPEG for display.</p>
+                    {% else %}
+                        <img src="/-/media/photo/{{ id }}" alt="{{ photo.FileName }}">
+                    {% endif %}
                 {% else %}
-                {% set path_parts = photo.full_path.split('/') %}
-                <p class="info">File not available - drive "{{ path_parts[2] if path_parts|length > 2 else 'external storage' }}" is not connected.</p>
+                    {% set path_parts = photo.full_path.split('/') %}
+                    <p class="info">File not available - drive "{{ path_parts[2] if path_parts|length > 2 else 'external storage' }}" is not connected.</p>
                 {% endif %}
             </div>
 

--- a/datasette/templates/pages/photo/{id}.html
+++ b/datasette/templates/pages/photo/{id}.html
@@ -96,10 +96,10 @@
                 {% set back_end = request.args.get('end_date', '') %}
                 {% set back_page = request.args.get('page', '') %}
                 {% set back_url = '/gallery?' %}
-                {% if back_q %}{% set back_url = back_url ~ 'q=' ~ back_q ~ '&' %}{% endif %}
-                {% if back_start %}{% set back_url = back_url ~ 'start_date=' ~ back_start ~ '&' %}{% endif %}
-                {% if back_end %}{% set back_url = back_url ~ 'end_date=' ~ back_end ~ '&' %}{% endif %}
-                {% if back_page %}{% set back_url = back_url ~ 'page=' ~ back_page %}{% endif %}
+                {% if back_q %}{% set back_url = back_url ~ 'q=' ~ back_q|urlencode ~ '&' %}{% endif %}
+                {% if back_start %}{% set back_url = back_url ~ 'start_date=' ~ back_start|urlencode ~ '&' %}{% endif %}
+                {% if back_end %}{% set back_url = back_url ~ 'end_date=' ~ back_end|urlencode ~ '&' %}{% endif %}
+                {% if back_page %}{% set back_url = back_url ~ 'page=' ~ back_page|urlencode %}{% endif %}
                 <a href="{{ back_url }}">← Back to gallery</a>
                 &nbsp;&nbsp;
                 <a href="/mediameta/exif_with_fullpath?FileName={{ id }}">View in database</a>
@@ -111,10 +111,10 @@
                 {% set is_raw = ext in raw_formats %}
                 {% if photo.full_path|file_exists %}
                     {% if is_raw %}
-                        <img src="/raw-photo/{{ id }}" alt="{{ photo.FileName }}">
+                        <img src="/raw-photo/{{ id|urlencode }}" alt="{{ photo.FileName }}">
                         <p class="info" style="margin-top: 12px;">RAW file ({{ ext|upper }}) — converted to JPEG for display.</p>
                     {% else %}
-                        <img src="/-/media/photo/{{ id }}" alt="{{ photo.FileName }}">
+                        <img src="/-/media/photo/{{ id|urlencode }}" alt="{{ photo.FileName }}">
                     {% endif %}
                 {% else %}
                     {% set path_parts = photo.full_path.split('/') %}


### PR DESCRIPTION
## Summary

- Add on-the-fly RAW→JPEG conversion (`raw_photo.py` plugin using rawpy) so NEF/CR2/ARW etc. display as full-resolution images in the browser
- Photo page detects RAW file extensions and routes to `/raw-photo/<filename>` instead of `/-/media/photo/`
- Add **← Back to gallery** link on photo page that preserves date filters and search query
- Gallery photo links now carry filter state (dates, page) so back navigation returns to the correct view
- Replace Prev/Next pagination with numbered page links showing current position (e.g. `← Prev 1 2 [3] 4 5 … 20 Next →`)
- Show total count and range ("Showing 101–200 of 847 photos")
- Sort ASC when start_date is set so photos appear from the beginning of the selected range

## Test plan

- [ ] Click a NEF thumbnail — full resolution image loads (allow 2-5s for RAW conversion)
- [ ] Click a JPEG thumbnail — loads as before via `/-/media/photo/`
- [ ] Navigate to a photo, then click ← Back to gallery — returns to correct filtered page
- [ ] Set date range, verify page numbers appear and total count is shown
- [ ] Jump to a non-adjacent page number

🤖 Generated with [Claude Code](https://claude.com/claude-code)