### PR TITLE
Add GPS photo map with thumbnail popups and gallery nav link

### DIFF
--- a/datasette/datasette.yaml
+++ b/datasette/datasette.yaml
@@ -29,6 +29,11 @@ plugins:
   datasette-cluster-map:
     latitude_column: GPSLatitude
     longitude_column: GPSLongitude
+    tile_layer: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+    tile_layer_options:
+      attribution: "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors &copy; <a href='https://carto.com/attributions'>CARTO</a>"
+      subdomains: "abcd"
+      maxZoom: 19
 
 # Database and table-level configuration
 databases:
@@ -44,9 +49,9 @@ databases:
           ORDER BY exif.CreateDate ASC;
       Show Time Matches all dates:
         sql: SELECT
-          thumbImages.content,
           exif.CreateDate,
           exif.FileName,
+          exif.SourceFile,
           thumbImages.size
           FROM
           exif
@@ -61,7 +66,7 @@ databases:
           exif
           WHERE
           CreateDate IS NOT NULL
-          AND exif.CreateDate <> ''
+          AND CreateDate <> ''
           GROUP BY
           CreateDate
           HAVING
@@ -78,3 +83,18 @@ databases:
         sql: SELECT format("%,d", SUM(FileSize)) AS TotalSize FROM Filenames;
       Number of .nef files:
         sql: SELECT COUNT(*) AS NEFCount FROM filenames WHERE LOWER(FileName) LIKE '%.nef';
+      Photo Map:
+        sql: >-
+          SELECT
+            e.GPSLatitude,
+            e.GPSLongitude,
+            json_object(
+              'image', '/-/media/thumb/' || replace(t.path, './', ''),
+              'title', e.FileName,
+              'description', e.CreateDate,
+              'link', '/photo/' || e.FileName
+            ) AS popup
+          FROM exif e
+          INNER JOIN thumbImages t ON e.SourceFile = t.path
+          WHERE e.GPSLatitude IS NOT NULL AND e.GPSLatitude != ''
+          AND e.GPSLongitude IS NOT NULL AND e.GPSLongitude != ''

--- a/datasette/datasette.yaml
+++ b/datasette/datasette.yaml
@@ -83,16 +83,23 @@ databases:
         sql: SELECT format("%,d", SUM(FileSize)) AS TotalSize FROM Filenames;
       Number of .nef files:
         sql: SELECT COUNT(*) AS NEFCount FROM filenames WHERE LOWER(FileName) LIKE '%.nef';
+      Photos with GPS:
+        sql: >-
+          SELECT FileName, SourceFile, GPSLatitude, GPSLongitude, CreateDate
+          FROM exif
+          WHERE GPSLatitude IS NOT NULL AND GPSLatitude != ''
+          AND GPSLongitude IS NOT NULL AND GPSLongitude != ''
+          ORDER BY CreateDate DESC
       Photo Map:
         sql: >-
           SELECT
             e.GPSLatitude,
             e.GPSLongitude,
             json_object(
-              'image', '/-/media/thumb/' || replace(t.path, './', ''),
+              'image', replace(t.path, './', ''),
               'title', e.FileName,
               'description', e.CreateDate,
-              'link', '/photo/' || e.FileName
+              'link', e.FileName
             ) AS popup
           FROM exif e
           INNER JOIN thumbImages t ON e.SourceFile = t.path

--- a/datasette/templates/database-mediameta.html
+++ b/datasette/templates/database-mediameta.html
@@ -2,10 +2,18 @@
 
 {% block description_source_license %}
 {{ super() }}
-<div style="margin: 15px 0; padding: 15px; background-color: #f0f9ff; border-left: 4px solid #4a9eff; border-radius: 4px;">
-    <a href="/gallery" style="font-size: 18px; font-weight: 600; color: #4a9eff; text-decoration: none;">
-        <span aria-hidden="true">📷</span> View Photo Gallery
-    </a>
-    <p style="margin: 5px 0 0 0; font-size: 14px; color: #666;">Browse your photo collection with date filtering</p>
+<div style="margin: 15px 0; display: flex; gap: 12px; flex-wrap: wrap;">
+    <div style="padding: 15px; background-color: #f0f9ff; border-left: 4px solid #4a9eff; border-radius: 4px;">
+        <a href="/gallery" style="font-size: 18px; font-weight: 600; color: #4a9eff; text-decoration: none;">
+            <span aria-hidden="true">📷</span> View Photo Gallery
+        </a>
+        <p style="margin: 5px 0 0 0; font-size: 14px; color: #666;">Browse your photo collection with date filtering</p>
+    </div>
+    <div style="padding: 15px; background-color: #f0fff4; border-left: 4px solid #38a169; border-radius: 4px;">
+        <a href="/map" style="font-size: 18px; font-weight: 600; color: #38a169; text-decoration: none;">
+            <span aria-hidden="true">🗺️</span> Photo Map
+        </a>
+        <p style="margin: 5px 0 0 0; font-size: 14px; color: #666;">Browse photos by GPS location</p>
+    </div>
 </div>
 {% endblock %}

--- a/datasette/templates/pages/gallery.html
+++ b/datasette/templates/pages/gallery.html
@@ -83,6 +83,14 @@
         .reset-link:hover {
             color: #e0e0e0;
         }
+        .nav-link {
+            color: #999;
+            text-decoration: none;
+            font-size: 13px;
+        }
+        .nav-link:hover {
+            color: #e0e0e0;
+        }
         .gallery-info {
             margin: 20px 0;
             color: #999;
@@ -302,7 +310,7 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>Photo Gallery</h1>
+            <h1>Photo Gallery <a href="/mediameta" class="nav-link">← Home</a></h1>
 
             <form class="filter-form" method="get" id="filterForm">
                 <div class="form-group">

--- a/datasette/templates/pages/map.html
+++ b/datasette/templates/pages/map.html
@@ -88,7 +88,7 @@
             WHERE e.GPSLatitude IS NOT NULL AND e.GPSLatitude != ''
             AND e.GPSLongitude IS NOT NULL AND e.GPSLongitude != ''`;
 
-        fetch('/mediameta.json?sql=' + encodeURIComponent(sql) + '&_shape=array&_size=max')
+        fetch('/mediameta.json?sql=' + encodeURIComponent(sql) + '&_shape=array&_size=10000')
             .then(function(r) { return r.json(); })
             .then(function(rows) {
                 document.getElementById('loading').style.display = 'none';
@@ -98,19 +98,43 @@
                     const lng = parseFloat(row.GPSLongitude);
                     if (isNaN(lat) || isNaN(lng)) return;
 
-                    const thumbUrl = '/-/media/thumb/' + row.SourceFile.replace('./', '');
+                    const sourcePath = row.SourceFile ? row.SourceFile.replace(/^\.\//, '') : '';
+                    const thumbUrl = '/-/media/thumb/' + encodeURI(sourcePath);
                     const dateStr = row.CreateDate ? row.CreateDate.substring(0, 10) : '';
                     const photoUrl = '/photo/' + encodeURIComponent(row.FileName);
 
-                    const popup = '<a href="' + photoUrl + '">'
-                        + '<img class="popup-thumb" src="' + thumbUrl + '" alt="' + row.FileName + '" loading="lazy">'
-                        + '</a>'
-                        + '<div class="popup-title">' + row.FileName + '</div>'
-                        + (dateStr ? '<div class="popup-date">' + dateStr + '</div>' : '')
-                        + '<a class="popup-link" href="' + photoUrl + '">View photo →</a>';
+                    const popupDiv = document.createElement('div');
+
+                    const thumbLink = document.createElement('a');
+                    thumbLink.href = photoUrl;
+                    const thumbImg = document.createElement('img');
+                    thumbImg.className = 'popup-thumb';
+                    thumbImg.src = thumbUrl;
+                    thumbImg.alt = row.FileName || '';
+                    thumbImg.loading = 'lazy';
+                    thumbLink.appendChild(thumbImg);
+                    popupDiv.appendChild(thumbLink);
+
+                    const titleDiv = document.createElement('div');
+                    titleDiv.className = 'popup-title';
+                    titleDiv.textContent = row.FileName || '';
+                    popupDiv.appendChild(titleDiv);
+
+                    if (dateStr) {
+                        const dateDiv = document.createElement('div');
+                        dateDiv.className = 'popup-date';
+                        dateDiv.textContent = dateStr;
+                        popupDiv.appendChild(dateDiv);
+                    }
+
+                    const viewLink = document.createElement('a');
+                    viewLink.className = 'popup-link';
+                    viewLink.href = photoUrl;
+                    viewLink.textContent = 'View photo \u2192';
+                    popupDiv.appendChild(viewLink);
 
                     L.marker([lat, lng])
-                        .bindPopup(popup, { maxWidth: 220 })
+                        .bindPopup(popupDiv, { maxWidth: 220 })
                         .addTo(markers);
                 });
 

--- a/datasette/templates/pages/map.html
+++ b/datasette/templates/pages/map.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Photo Map</title>
+    <link rel="stylesheet" href="/-/static-plugins/datasette-leaflet/leaflet-v1.7.1.css">
+    <link rel="stylesheet" href="/-/static-plugins/datasette-cluster-map/leaflet.markercluster.css">
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+        #map { height: 100vh; width: 100%; }
+        .nav-bar {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            z-index: 1000;
+            display: flex;
+            gap: 8px;
+        }
+        .nav-bar a {
+            background: white;
+            padding: 6px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-size: 13px;
+            color: #333;
+            box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+        }
+        .nav-bar a:hover { background: #f5f5f5; }
+        .loading {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            z-index: 1000;
+            background: white;
+            padding: 16px 24px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+            font-size: 14px;
+            color: #555;
+        }
+        .popup-thumb {
+            width: 200px;
+            height: 150px;
+            object-fit: cover;
+            display: block;
+            border-radius: 4px;
+            margin-bottom: 8px;
+        }
+        .popup-title {
+            font-weight: 600;
+            font-size: 13px;
+            margin-bottom: 4px;
+            word-break: break-all;
+        }
+        .popup-date { color: #666; font-size: 12px; margin-bottom: 8px; }
+        .popup-link { color: #4a9eff; font-size: 13px; text-decoration: none; }
+        .popup-link:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <div class="nav-bar">
+        <a href="/gallery">← Gallery</a>
+        <a href="/mediameta">Datasette</a>
+    </div>
+    <div class="loading" id="loading">Loading photos...</div>
+
+    <script type="module">
+    import * as L from '/-/static-plugins/datasette-leaflet/leaflet-v1.7.1.min.js';
+    import { MarkerClusterGroup } from '/-/static-plugins/datasette-cluster-map/leaflet.markercluster.min.js';
+
+    (function() {
+        const map = L.map('map');
+
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+            subdomains: 'abcd',
+            maxZoom: 19
+        }).addTo(map);
+
+        const markers = new MarkerClusterGroup();
+
+        const sql = `SELECT e.GPSLatitude, e.GPSLongitude, e.FileName, e.SourceFile, e.CreateDate
+            FROM exif e
+            INNER JOIN thumbImages t ON e.SourceFile = t.path
+            WHERE e.GPSLatitude IS NOT NULL AND e.GPSLatitude != ''
+            AND e.GPSLongitude IS NOT NULL AND e.GPSLongitude != ''`;
+
+        fetch('/mediameta.json?sql=' + encodeURIComponent(sql) + '&_shape=array&_size=max')
+            .then(function(r) { return r.json(); })
+            .then(function(rows) {
+                document.getElementById('loading').style.display = 'none';
+
+                rows.forEach(function(row) {
+                    const lat = parseFloat(row.GPSLatitude);
+                    const lng = parseFloat(row.GPSLongitude);
+                    if (isNaN(lat) || isNaN(lng)) return;
+
+                    const thumbUrl = '/-/media/thumb/' + row.SourceFile.replace('./', '');
+                    const dateStr = row.CreateDate ? row.CreateDate.substring(0, 10) : '';
+                    const photoUrl = '/photo/' + encodeURIComponent(row.FileName);
+
+                    const popup = '<a href="' + photoUrl + '">'
+                        + '<img class="popup-thumb" src="' + thumbUrl + '" alt="' + row.FileName + '" loading="lazy">'
+                        + '</a>'
+                        + '<div class="popup-title">' + row.FileName + '</div>'
+                        + (dateStr ? '<div class="popup-date">' + dateStr + '</div>' : '')
+                        + '<a class="popup-link" href="' + photoUrl + '">View photo →</a>';
+
+                    L.marker([lat, lng])
+                        .bindPopup(popup, { maxWidth: 220 })
+                        .addTo(markers);
+                });
+
+                map.addLayer(markers);
+                if (markers.getLayers().length > 0) {
+                    map.fitBounds(markers.getBounds(), { padding: [40, 40] });
+                } else {
+                    map.setView([0, 0], 2);
+                }
+            })
+            .catch(function() {
+                document.getElementById('loading').textContent = 'Failed to load photo locations.';
+            });
+    })();
+    </script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "transformers",
     "uvicorn",
     "pydantic>=2.12.5",
+    "datasette-cluster-map>=0.18.2",
 ]
 
 [tool.hatch.build]

--- a/uv.lock
+++ b/uv.lock
@@ -442,6 +442,31 @@ wheels = [
 ]
 
 [[package]]
+name = "datasette-cluster-map"
+version = "0.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasette" },
+    { name = "datasette-leaflet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/73/82fbe3d6f3202a724dc686550c4e1ea373e601f29d0add0df03383d6819a/datasette_cluster_map-0.18.2.tar.gz", hash = "sha256:6ae34faf0f2e3198cbfdc06faaf65ac43a4e3be02d916e4d69dd5e25abcc8b28", size = 38463 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/55/e62144a08b469f7467525171e89c868a684db3026b80d6130592024ed816/datasette_cluster_map-0.18.2-py3-none-any.whl", hash = "sha256:8074cdd42a7c1c4e95d52a3c5b0029eb7e5fe978498855d1ec804adadfd2b041", size = 35054 },
+]
+
+[[package]]
+name = "datasette-leaflet"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "datasette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/6e/444b1ded1cd8f71cd86f4461c06ee88be2bb0682b0d54aa942c323f91411/datasette-leaflet-0.2.2.tar.gz", hash = "sha256:8fd4e634304be392ae6f7de770d4f22b95a37caecd676a35faeb6200da9423bc", size = 113285 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/df/61e8a7d601a2c4992f7e9f38a6b983a9f9b873fbeebe4248090eea4b5d87/datasette_leaflet-0.2.2-py3-none-any.whl", hash = "sha256:fd88c25666e7680b25b4c6e5546bd02c9f5836bbc0fee61042dbb6b93d4139f0", size = 112532 },
+]
+
+[[package]]
 name = "datasette-media"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1364,6 +1389,7 @@ dependencies = [
     { name = "datasette" },
     { name = "datasette-auth-passwords" },
     { name = "datasette-checkbox" },
+    { name = "datasette-cluster-map" },
     { name = "datasette-media" },
     { name = "datasette-render-images" },
     { name = "datasette-template-sql" },
@@ -1410,6 +1436,7 @@ requires-dist = [
     { name = "datasette", specifier = "==1.0a24" },
     { name = "datasette-auth-passwords" },
     { name = "datasette-checkbox" },
+    { name = "datasette-cluster-map", specifier = ">=0.18.2" },
     { name = "datasette-media" },
     { name = "datasette-render-images" },
     { name = "datasette-template-sql", specifier = ">=1.0.2" },


### PR DESCRIPTION
## Summary
- Adds a `← Home` nav link to the Photo Gallery page linking back to `/mediameta`
- Installs `datasette-cluster-map` plugin and configures CartoDB tiles (avoids OSM localhost referer block)
- Adds a custom `/map` page with full-screen Leaflet + MarkerCluster showing GPS-tagged photos as clustered pins with thumbnail popups
- Links to the map page added from the `/mediameta` database page

## Test plan
- [ ] Visit `/gallery` — confirm "← Home" link appears next to the title
- [ ] Visit `/mediameta` — confirm "Photo Map" card appears alongside "View Photo Gallery"
- [ ] Visit `/map` — confirm map loads, pins cluster, clicking a pin shows thumbnail + date + link
- [ ] Confirm thumbnails in popups load (not full-size photos)
- [ ] Confirm "← Gallery" and "Datasette" nav links in top-right of map work

🤖 Generated with [Claude Code](https://claude.com/claude-code)